### PR TITLE
format transaction cards to prevent text overlap

### DIFF
--- a/src/components/RunningTotal.tsx
+++ b/src/components/RunningTotal.tsx
@@ -66,8 +66,8 @@ function RunningTotal()
     //<Text style = {[ totalStyles.balanceText, {position: 'absolute', right: 111, top: 50} ]}> {balance} </Text>
     return (
       <View style = {totalStyles.card}>
-        <Text style = {[ totalStyles.incomeText, {position: 'absolute', left: 0, top: 0} ]}> {"Total Income: $" + income} </Text>
-        <Text style = {[ totalStyles.expenseText, {position: 'absolute', right: 5, top: 0} ]}> {"Total Expenses: $" + expenses} </Text>
+        <Text style = {[ totalStyles.incomeText, {position: 'absolute', left: 0, top: 0} ]}> {"Total Income: $" + income.toFixed(2)} </Text>
+        <Text style = {[ totalStyles.expenseText, {position: 'absolute', right: 5, top: 0} ]}> {"Total Expenses: $" + expenses.toFixed(2)} </Text>
       </View>
     );
 }

--- a/src/components/RunningTotal.tsx
+++ b/src/components/RunningTotal.tsx
@@ -13,7 +13,7 @@ const totalStyles = StyleSheet.create
       alignSelf: 'center',
       backgroundColor: '#DBDBD9',
       height: 12,
-      width: 333,
+      width: 365,
       borderRadius: 0,
       borderWidth: 0,
       borderColor: 'black',      

--- a/src/components/RunningTotal.tsx
+++ b/src/components/RunningTotal.tsx
@@ -9,7 +9,7 @@ const totalStyles = StyleSheet.create
 ({
     card: 
     {
-      top: 62,
+      top: 75,
       alignSelf: 'center',
       backgroundColor: '#DBDBD9',
       height: 12,
@@ -50,12 +50,12 @@ function RunningTotal()
     for(var i = 0; i < testTransactionsAsJSON.length; i++)
     {
       
-        if(testTransactionsAsJSON[i].type == "income")
+        if(testTransactionsAsJSON[i].type == 1)
         {
             income += testTransactionsAsJSON[i].amount;
 
         }
-        else if(testTransactionsAsJSON[i].type == "expense")
+        else if(testTransactionsAsJSON[i].type == 2)
         {
             expenses += testTransactionsAsJSON[i].amount;
         }

--- a/src/components/RunningTotal.tsx
+++ b/src/components/RunningTotal.tsx
@@ -22,21 +22,18 @@ const totalStyles = StyleSheet.create
     incomeText:
     {
       fontWeight: "bold",
-      fontFamily: "Times New Roman",
       fontSize: normalTextSize,
       color: '#008315',
     },
     expenseText:
     {
       fontWeight: "bold",
-      fontFamily: "Times New Roman",
       fontSize: normalTextSize,
       color: '#DB0000',
     },
     balanceText:
     {
       fontWeight: "bold",
-      fontFamily: "Times New Roman",
       fontSize: normalTextSize,
       color: '#0057D9',
     },    

--- a/src/components/RunningTotal.tsx
+++ b/src/components/RunningTotal.tsx
@@ -16,7 +16,8 @@ const totalStyles = StyleSheet.create
       width: 333,
       borderRadius: 0,
       borderWidth: 0,
-      borderColor: 'black',
+      borderColor: 'black',      
+      position: 'absolute',
     },
     incomeText:
     {

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -43,7 +43,7 @@ export interface Transaction
   category: string;
   subCategory: string;
   account: string;
-  type: 'income' | 'expense' | 'transfer';
+  type: number; //set this to 1 for income, 2 for expenses, or 3 for transfers
   amount: number;
 }
 
@@ -68,11 +68,11 @@ export default function TransactionCard({ transaction }: TransactionProps)
     transactionCategory.length > truncateSize ? transactionCategory.substring(0, truncateSize) + "..." :
     transactionCategory;
 
-  if(transaction.type == 'income')
+  if(transaction.type == 1)
   {
     amountStyle = styles.incomeText;
   }
-  else if(transaction.type == 'expense')
+  else if(transaction.type == 2)
   {
     amountStyle = styles.expenseText;
   }

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -14,7 +14,7 @@ const styles = StyleSheet.create
     },
     normalText:
     {
-      fontSize: 12,
+      fontSize: 14,
       color: 'black',
     },
     incomeText:
@@ -56,6 +56,15 @@ export default function TransactionCard({ transaction }: TransactionProps)
     transaction.subCategory == "" ? transaction.category :
     `${transaction.category} - ${transaction.subCategory}`;
 
+  {/*truncate both the account name and the category name so that they do not overlap with the transcation amount*/}
+  let truncateSize = 30;
+  let accountName: string =
+    transaction.account.length > truncateSize ? transaction.account.substring(0, truncateSize) + "..." :
+    transaction.account;
+  let categoryName: string =
+    transactionCategory.length > truncateSize ? transactionCategory.substring(0, truncateSize) + "..." :
+    transactionCategory;
+
   if(transaction.type == 'income')
   {
     amountStyle = styles.incomeText;
@@ -71,9 +80,8 @@ export default function TransactionCard({ transaction }: TransactionProps)
 
   return (
     <View style = {styles.card}>
-      <Text style = {[ styles.normalText, {position: 'absolute', left: 0, top: 0} ]}> {transaction.date} </Text>
-      <Text style = {[ styles.normalText, {position: 'absolute', left: 0, bottom: 1} ]}> {transactionCategory} </Text>
-      <Text style = {[ styles.normalText, {position: 'absolute', left: 125, top: 20} ]}> {transaction.account} </Text>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
       <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${transaction.amount}`} </Text>
     </View>
   );

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -83,7 +83,7 @@ export default function TransactionCard({ transaction }: TransactionProps)
 
   return (
     <View style = {styles.card}>
-      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {/*accountName*/transaction.date} </Text>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
       <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
       <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${transaction.amount}`} </Text>
     </View>

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -102,27 +102,12 @@ export default function TransactionCard({ transaction }: TransactionProps)
       denom = "B";
       toggleAltFormat = true;
   }
-
-
-  if(toggleAltFormat)
-  {
-    return (
-      <View style = {styles.card}>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 0, top: 0} ]}> {transaction.date} </Text>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 0, bottom: 1} ]}> {transactionCategory} </Text>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 125, top: 20} ]}> {transaction.account} </Text>
-        <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${pseudoAmount.toFixed(2) + denom}`} </Text>
-      </View>
-    );
-  }
-  else
-  {
+  
   return (
     <View style = {styles.card}>
       <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
       <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
-      <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${transaction.amount}`} </Text>
+      <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {toggleAltFormat ? `$${pseudoAmount.toFixed(2) + denom}` : `$${transaction.amount}`} </Text>
     </View>
   );
-  }
 }

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -103,23 +103,11 @@ export default function TransactionCard({ transaction }: TransactionProps)
       toggleAltFormat = true;
   }
   
-  if(toggleAltFormat)
-  {
-    return (
-      <View style = {styles.card}>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 0, bottom: 20} ]}> {transactionCategory} </Text>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 125, top: 20} ]}> {transaction.account} </Text>
-        <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${pseudoAmount.toFixed(2) + denom}`} </Text>
-      </View>
-    );
-  }
-  else
-  {
-    return (
-      <View style = {styles.card}>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
-        <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
-        <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {toggleAltFormat ? `$${pseudoAmount.toFixed(2) + denom}` : `$${transaction.amount}`} </Text>
-      </View>
+  return (
+    <View style = {styles.card}>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
+      <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {toggleAltFormat ? `$${pseudoAmount.toFixed(2) + denom}` : `$${transaction.amount}`} </Text>
+    </View>
   );
 }

--- a/src/components/TransactionCards.tsx
+++ b/src/components/TransactionCards.tsx
@@ -37,6 +37,9 @@ const styles = StyleSheet.create
 export interface Transaction
 {
   date: string;
+  month: number,
+  day: number,
+  year: number,
   category: string;
   subCategory: string;
   account: string;
@@ -80,7 +83,7 @@ export default function TransactionCard({ transaction }: TransactionProps)
 
   return (
     <View style = {styles.card}>
-      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {accountName} </Text>
+      <Text style = {[ styles.normalText, {position: 'absolute', left: 3, top: 5} ]}> {/*accountName*/transaction.date} </Text>
       <Text style = {[ styles.normalText, {position: 'absolute', left: 3, bottom: 7} ]}> {categoryName} </Text>
       <Text style = {[ amountStyle, {position: 'absolute', right: 0, top: 15} ]}> {`$${transaction.amount}`} </Text>
     </View>

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -22,6 +22,10 @@ const styles = StyleSheet.create
       paddingTop: 10,
       paddingLeft: 170,
     },
+    scrollView:
+    {
+      marginVertical: 10,
+    },
 });
 
 function TransactionLog() : JSX.Element {
@@ -57,7 +61,7 @@ function TransactionLog() : JSX.Element {
       <View style = {{height: 10}}/>
 
       {/*Render the transaction cards*/}
-      <ScrollView>
+      <ScrollView style = {styles.scrollView}>
 
         {/*Map an array of our test transactions to transaction cards to be rendered*/}
         {testTransactionsAsJSON.map((transactionData) => (

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -97,7 +97,7 @@ function TransactionLog() : JSX.Element {
       <ScrollView style = {styles.scrollView}>
 
         {/*Map an array of our test transactions to transaction cards to be rendered*/}
-        {testTransactionsAsJSON.map((transactionData) => (
+        {testTransactionsAsJSON.map((transactionData, index) => (
 
           //Only render a transaction if the user selected it's type in the view toggle
           //AND if the user selected it's time period
@@ -112,7 +112,7 @@ function TransactionLog() : JSX.Element {
             (selectedTimePeriod == 3 && transactionData.year == currentYear)
           ) ?
           (
-            <View style = {styles.cards}>
+            <View style = {styles.cards} key = {index}>
               <TransactionCard transaction = {transactionData}/>
             </View>
           )

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -10,6 +10,7 @@ const styles = StyleSheet.create
     {
       flex: 1,
       backgroundColor: '#DBDBD9',
+      alignItems: 'center',
     },
     cards: 
     {
@@ -17,19 +18,28 @@ const styles = StyleSheet.create
       top: 20,
       padding: 3,
     },
+    timeToggle:
+    {
+      top: 20,
+      left: 40,
+      position: 'absolute',
+    },
     viewToggle:
     {
-      paddingTop: 10,
-      paddingLeft: 170,
+      top: 20,
+      right: 32,
+      position: 'absolute',
     },
     scrollView:
     {
-      marginVertical: 10,
+      marginVertical: 70,
+      position: 'absolute',
     },
 });
 
 function TransactionLog() : JSX.Element {
 
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState("all");
   const [selectedView, setSelectedView] = useState("all");
 
   return (
@@ -37,6 +47,26 @@ function TransactionLog() : JSX.Element {
       
       {/*Render the running total*/}
       <RunningTotal/>
+
+      {/*Render the time toggle button*/}
+      <View style = {styles.timeToggle}> 
+
+        <Picker
+          selectedValue = {selectedTimePeriod}
+          style = {{ height: 50, width: 150 }}
+          onValueChange = {(itemValue) => setSelectedTimePeriod(itemValue)}
+        >      
+
+          {/*list options for time toggle*/}
+          <Picker.Item label = "All Time" value = "all" />
+          <Picker.Item label = "Daily" value = "daily" />
+          <Picker.Item label = "Weekly" value = "weekly" />
+          <Picker.Item label = "Monthly" value = "monthly" />
+          <Picker.Item label = "Yearly" value = "yearly" />
+
+        </Picker>     
+
+      </View>    
 
       {/*Render the view toggle button*/}
       <View style = {styles.viewToggle}> 
@@ -48,7 +78,7 @@ function TransactionLog() : JSX.Element {
         >      
 
           {/*list options for view toggle*/}
-          <Picker.Item label = "All" value = "all" />
+          <Picker.Item label = "All Types" value = "all" />
           <Picker.Item label = "Income" value = "income" />
           <Picker.Item label = "Expenses" value = "expense" />
           <Picker.Item label = "Transfers" value = "transfer" />

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -38,8 +38,13 @@ const styles = StyleSheet.create
 
 function TransactionLog() : JSX.Element {
 
-  const [selectedTimePeriod, setSelectedTimePeriod] = useState("all");
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState("daily");
   const [selectedView, setSelectedView] = useState("all");
+
+  //we should render the most recent transactions by default
+  let currentDay = testTransactionsAsJSON[0].day;
+  let currentMonth = testTransactionsAsJSON[0].month;
+  let currentYear = testTransactionsAsJSON[0].year;
 
   return (
     <View style = {styles.screen}>
@@ -53,11 +58,30 @@ function TransactionLog() : JSX.Element {
         <Picker
           selectedValue = {selectedTimePeriod}
           style = {{ height: 50, width: 150 }}
-          onValueChange = {(itemValue) => setSelectedTimePeriod(itemValue)}
+          onValueChange = {(itemValue) => {
+
+            setSelectedTimePeriod(itemValue);
+
+            if(itemValue == "daily")
+            {
+              currentDay = testTransactionsAsJSON[0].day;
+            }
+            else if(itemValue == "weekly")
+            {
+              currentDay = testTransactionsAsJSON[0].day;
+            }
+            else if(itemValue == "monthly")
+            {
+              currentMonth = testTransactionsAsJSON[0].month;
+            }
+            else if(itemValue == "yearly")
+            {
+              currentYear = testTransactionsAsJSON[0].year;
+            }
+          }}
         >      
 
           {/*list options for time toggle*/}
-          <Picker.Item label = "All Time" value = "all" />
           <Picker.Item label = "Daily" value = "daily" />
           <Picker.Item label = "Weekly" value = "weekly" />
           <Picker.Item label = "Monthly" value = "monthly" />
@@ -94,11 +118,19 @@ function TransactionLog() : JSX.Element {
 
         {/*Map an array of our test transactions to transaction cards to be rendered*/}
         {testTransactionsAsJSON.map((transactionData) => (
-          
+
           //Only render a transaction if the user selected it's type in the view toggle
-          //AND the user selected it's time period in the view toggle
+          //AND if the user selected it's time period
           (transactionData.type == selectedView || selectedView == "all") &&
-          (transactionData.date == selectedTimePeriod || selectedTimePeriod == "all") ?
+          (
+            (selectedTimePeriod == "daily" && transactionData.day == currentDay) ||
+            (selectedTimePeriod == "weekly" && transactionData.day <= currentDay && 
+            transactionData.day > currentDay - 7 &&
+            transactionData.month == currentMonth && 
+            transactionData.year == currentYear) ||
+            (selectedTimePeriod == "monthly" && transactionData.month == currentMonth) ||
+            (selectedTimePeriod == "yearly" && transactionData.year == currentYear)
+          ) ?
           (
             <View style = {styles.cards}>
               <TransactionCard transaction = {transactionData}/>
@@ -120,9 +152,13 @@ function TransactionLog() : JSX.Element {
 export default TransactionLog;
 
 //The following JSON is temporary!
+//The most recent transaction goes to the top of this array.
 export const testTransactionsAsJSON: Transaction[] = [
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'A Really Really Long Category Name',
     subCategory: '',
     account: 'A Really Really Long Account Name',
@@ -131,6 +167,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'Dogecoin Returns',
     subCategory: '',
     account: 'Crypto Wallet',
@@ -139,6 +178,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
@@ -147,6 +189,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
@@ -155,6 +200,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
@@ -163,6 +211,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    month: 9,
+    day: 25,
+    year: 2021,
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
@@ -171,6 +222,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 24, 2021 (Friday)',
+    month: 9,
+    day: 24,
+    year: 2021,
     category: 'Transfer',
     subCategory: '',
     account: 'Checking Account -> Savings Account',
@@ -179,6 +233,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 24, 2021 (Friday)',
+    month: 9,
+    day: 24,
+    year: 2021,
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
@@ -187,6 +244,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 23, 2021 (Thursday)',
+    month: 9,
+    day: 23,
+    year: 2021,
     category: 'Salary',
     subCategory: '',
     account: 'Checking Account',
@@ -195,6 +255,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 22, 2021 (Wednesday)',
+    month: 9,
+    day: 22,
+    year: 2021,
     category: 'Haircut',
     subCategory: '',
     account: 'Credit Card',
@@ -203,6 +266,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 22, 2021 (Wednesday)',
+    month: 9,
+    day: 22,
+    year: 2021,
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
@@ -211,6 +277,9 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 22, 2021 (Wednesday)',
+    month: 9,
+    day: 22,
+    year: 2021,
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
@@ -219,6 +288,53 @@ export const testTransactionsAsJSON: Transaction[] = [
   },
   {
     date: 'Sept. 22, 2021 (Wednesday)',
+    month: 9,
+    day: 22,
+    year: 2021,
+    category: 'Groceries',
+    subCategory: '',
+    account: 'Checking Account',
+    type: 'expense',
+    amount: 214,
+  },
+  {
+    date: 'Oct. 22, 2021 (Wednesday)',
+    month: 10,
+    day: 22,
+    year: 2021,
+    category: 'Groceries',
+    subCategory: '',
+    account: 'Checking Account',
+    type: 'expense',
+    amount: 23.12,
+  },
+  {
+    date: 'Oct. 22, 2021 (Wednesday)',
+    month: 10,
+    day: 22,
+    year: 2021,
+    category: 'Groceries',
+    subCategory: '',
+    account: 'Checking Account',
+    type: 'expense',
+    amount: 214,
+  },
+  {
+    date: 'Jan. 22, 2022 (Wednesday)',
+    month: 1,
+    day: 22,
+    year: 2022,
+    category: 'Groceries',
+    subCategory: '',
+    account: 'Checking Account',
+    type: 'expense',
+    amount: 23.12,
+  },
+  {
+    date: 'Jan. 22, 2022 (Wednesday)',
+    month: 1,
+    day: 22,
+    year: 2022,
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -122,7 +122,12 @@ function TransactionLog() : JSX.Element {
           ) ?
           (
             <View style = {styles.cards} key = {index}>
-              {index === 0 || transactionData.date !== testTransactionsAsJSON[index-1].date || transactionData.type !== testTransactionsAsJSON[index-1].type && selectedView !== 'all' ? <DateLabel date={transactionData.date}/>  : null}
+              { 
+                index === 0 || transactionData.date !== testTransactionsAsJSON[index-1].date || 
+                transactionData.type !== testTransactionsAsJSON[index-1].type && selectedView !== 0 ?
+                <DateLabel date={transactionData.date}/>  
+                : null
+              }
               <TransactionCard transaction = {transactionData}/>
             </View>
           )

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -32,8 +32,7 @@ const styles = StyleSheet.create
     },
     scrollView:
     {
-      marginVertical: 70,
-      position: 'absolute',
+      marginVertical: 80,
     },
 });
 
@@ -97,7 +96,9 @@ function TransactionLog() : JSX.Element {
         {testTransactionsAsJSON.map((transactionData) => (
           
           //Only render a transaction if the user selected it's type in the view toggle
-          transactionData.type == selectedView || selectedView == "all" ?
+          //AND the user selected it's time period in the view toggle
+          (transactionData.type == selectedView || selectedView == "all") &&
+          (transactionData.date == selectedTimePeriod || selectedTimePeriod == "all") ?
           (
             <View style = {styles.cards}>
               <TransactionCard transaction = {transactionData}/>

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -1,7 +1,6 @@
 import React, { useState }  from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { TouchableOpacity, ScrollView, StyleSheet, View, Text } from 'react-native';
 import TransactionCard, { Transaction } from '../components/TransactionCards';
-import { Picker } from '@react-native-picker/picker';
 import RunningTotal from '../components/RunningTotal';
 
 const styles = StyleSheet.create
@@ -20,15 +19,39 @@ const styles = StyleSheet.create
     },
     timeToggle:
     {
-      top: 20,
-      left: 40,
+      width: 100,
+      height: 35,
       position: 'absolute',
+      top: 30,
+      left: 60,
+      borderWidth: 2,
+      borderColor: 'black',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+    },
+    timeToggleText:
+    {
+      color: 'black',
+      fontSize: 14,
     },
     viewToggle:
     {
-      top: 20,
-      right: 32,
+      width: 100,
+      height: 35,
       position: 'absolute',
+      top: 30,
+      right: 60,
+      borderWidth: 2,
+      borderColor: 'black',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+    },
+    viewToggleText:
+    {
+      color: 'black',
+      fontSize: 14,
     },
     scrollView:
     {
@@ -38,8 +61,13 @@ const styles = StyleSheet.create
 
 function TransactionLog() : JSX.Element {
 
-  const [selectedTimePeriod, setSelectedTimePeriod] = useState("daily");
-  const [selectedView, setSelectedView] = useState("all");
+  //0 for daily, 1 for weekly, 2 for monthly, 3 for yearly
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState(0);
+  const timeTitles: Array<string> = ['Daily', 'Weekly', 'Monthly', 'Yearly'];
+
+  //0 for all, 1 for income, 2 for expenses, 3 for transfers
+  const [selectedView, setSelectedView] = useState(0);
+  const viewTitles: Array<string> = ['All', 'Income', 'Expenses', 'Transfers'];
 
   //we should render the most recent transactions by default
   let currentDay = testTransactionsAsJSON[0].day;
@@ -53,62 +81,14 @@ function TransactionLog() : JSX.Element {
       <RunningTotal/>
 
       {/*Render the time toggle button*/}
-      <View style = {styles.timeToggle}> 
-
-        <Picker
-          selectedValue = {selectedTimePeriod}
-          style = {{ height: 50, width: 150 }}
-          onValueChange = {(itemValue) => {
-
-            setSelectedTimePeriod(itemValue);
-
-            if(itemValue == "daily")
-            {
-              currentDay = testTransactionsAsJSON[0].day;
-            }
-            else if(itemValue == "weekly")
-            {
-              currentDay = testTransactionsAsJSON[0].day;
-            }
-            else if(itemValue == "monthly")
-            {
-              currentMonth = testTransactionsAsJSON[0].month;
-            }
-            else if(itemValue == "yearly")
-            {
-              currentYear = testTransactionsAsJSON[0].year;
-            }
-          }}
-        >      
-
-          {/*list options for time toggle*/}
-          <Picker.Item label = "Daily" value = "daily" />
-          <Picker.Item label = "Weekly" value = "weekly" />
-          <Picker.Item label = "Monthly" value = "monthly" />
-          <Picker.Item label = "Yearly" value = "yearly" />
-
-        </Picker>     
-
-      </View>    
+      <TouchableOpacity style = {styles.timeToggle} onPress = {() => setSelectedTimePeriod((selectedTimePeriod + 1) % 4)}>
+        <Text style = {styles.timeToggleText}>{timeTitles[selectedTimePeriod]}</Text>
+      </TouchableOpacity>
 
       {/*Render the view toggle button*/}
-      <View style = {styles.viewToggle}> 
-
-        <Picker
-          selectedValue = {selectedView}
-          style = {{ height: 50, width: 150 }}
-          onValueChange = {(itemValue) => setSelectedView(itemValue)}
-        >      
-
-          {/*list options for view toggle*/}
-          <Picker.Item label = "All Types" value = "all" />
-          <Picker.Item label = "Income" value = "income" />
-          <Picker.Item label = "Expenses" value = "expense" />
-          <Picker.Item label = "Transfers" value = "transfer" />
-
-        </Picker>     
-
-      </View>       
+      <TouchableOpacity style = {styles.viewToggle} onPress = {() => setSelectedView((selectedView + 1) % 4)}>
+          <Text style = {styles.viewToggleText}>{viewTitles[selectedView]}</Text>
+      </TouchableOpacity>
 
       {/*Pad the top of the scroll view so that it does not get overlapped*/}
       <View style = {{height: 10}}/>
@@ -121,15 +101,15 @@ function TransactionLog() : JSX.Element {
 
           //Only render a transaction if the user selected it's type in the view toggle
           //AND if the user selected it's time period
-          (transactionData.type == selectedView || selectedView == "all") &&
+          (transactionData.type == selectedView || selectedView == 0) &&
           (
-            (selectedTimePeriod == "daily" && transactionData.day == currentDay) ||
-            (selectedTimePeriod == "weekly" && transactionData.day <= currentDay && 
+            (selectedTimePeriod == 0 && transactionData.day == currentDay) ||
+            (selectedTimePeriod == 1 && transactionData.day <= currentDay && 
             transactionData.day > currentDay - 7 &&
             transactionData.month == currentMonth && 
             transactionData.year == currentYear) ||
-            (selectedTimePeriod == "monthly" && transactionData.month == currentMonth) ||
-            (selectedTimePeriod == "yearly" && transactionData.year == currentYear)
+            (selectedTimePeriod == 2 && transactionData.month == currentMonth) ||
+            (selectedTimePeriod == 3 && transactionData.year == currentYear)
           ) ?
           (
             <View style = {styles.cards}>
@@ -162,7 +142,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'A Really Really Long Category Name',
     subCategory: '',
     account: 'A Really Really Long Account Name',
-    type: 'income',
+    type: 1,
     amount: 100000,
   },
   {
@@ -173,7 +153,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Dogecoin Returns',
     subCategory: '',
     account: 'Crypto Wallet',
-    type: 'income',
+    type: 1,
     amount: 100000,
   },
   {
@@ -184,7 +164,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 24.12,
   },
   {
@@ -195,7 +175,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 14.15,
   },
   {
@@ -206,7 +186,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 54.20,
   },
   {
@@ -217,7 +197,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Food',
     subCategory: 'Fast Food',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 20.12,
   },
   {
@@ -228,7 +208,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Transfer',
     subCategory: '',
     account: 'Checking Account -> Savings Account',
-    type: 'transfer',
+    type: 3,
     amount: 100,
   },
   {
@@ -239,7 +219,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 54.12,
   },
   {
@@ -250,7 +230,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Salary',
     subCategory: '',
     account: 'Checking Account',
-    type: 'income',
+    type: 1,
     amount: 5652.40,
   },
   {
@@ -261,7 +241,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Haircut',
     subCategory: '',
     account: 'Credit Card',
-    type: 'expense',
+    type: 2,
     amount: 30,
   },
   {
@@ -272,7 +252,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 54.12,
   },
   {
@@ -283,7 +263,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 23.12,
   },
   {
@@ -294,7 +274,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 214,
   },
   {
@@ -305,7 +285,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 23.12,
   },
   {
@@ -316,7 +296,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 214,
   },
   {
@@ -327,7 +307,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 23.12,
   },
   {
@@ -338,7 +318,7 @@ export const testTransactionsAsJSON: Transaction[] = [
     category: 'Groceries',
     subCategory: '',
     account: 'Checking Account',
-    type: 'expense',
+    type: 2,
     amount: 214,
   },
 ];

--- a/src/screens/TransactionLog.tsx
+++ b/src/screens/TransactionLog.tsx
@@ -88,6 +88,14 @@ export default TransactionLog;
 export const testTransactionsAsJSON: Transaction[] = [
   {
     date: 'Sept. 25, 2021 (Saturday)',
+    category: 'A Really Really Long Category Name',
+    subCategory: '',
+    account: 'A Really Really Long Account Name',
+    type: 'income',
+    amount: 100000,
+  },
+  {
+    date: 'Sept. 25, 2021 (Saturday)',
     category: 'Dogecoin Returns',
     subCategory: '',
     account: 'Crypto Wallet',


### PR DESCRIPTION
When I was going to wrap the account names on each transaction card, I realized that it is unnecessary to have a transaction date displayed on each card since in Nader's PR, he created date dividers for each transaction grouped by day. So that makes fitting the account name and the category name on each transaction card a lot easier if we remove the transaction date. You will see what I mean if you run the changes I made to the code. 

Edit: This PR now closes #5 in addition to #9.